### PR TITLE
Ignore Draft Posts

### DIFF
--- a/lib/Contentful.js
+++ b/lib/Contentful.js
@@ -148,18 +148,20 @@ class Contentful {
     }
 
     if (fields[key].constructor === Array) {
-      fields[key] = fields[key].map((entry) => {
+      fields[key] = fields[key].reduce((m, entry) => {
         if (!(entry instanceof Object)) {
           return entry;
         }
 
         entry = this._cleanEntry(entry, true);
+        if (!entry.fields) return m
         entry = this._mergeFields(entry, entry.fields);
         entry = this._getFields(entry, locale);
         entry = this._getFieldsForLocale(entry, locale);
-
-        return entry;
-      });
+        
+        m.push(entry);
+        return m;
+      }, []);
     }
 
     return fields;

--- a/lib/Contentful.js
+++ b/lib/Contentful.js
@@ -152,8 +152,13 @@ class Contentful {
         if (!(entry instanceof Object)) {
           return entry;
         }
+        
+        // Assets are not indexed
+        if (entry.sys.type === 'Asset') return m
 
         entry = this._cleanEntry(entry, true);
+        
+        // Drafts are not indexed
         if (!entry.fields) return m
         entry = this._mergeFields(entry, entry.fields);
         entry = this._getFields(entry, locale);


### PR DESCRIPTION
Drafts coming from contentful are brutal. They go out with the output, but just don't have any fields. Unfortunately, this causes both this library and algolia to error, since it prefers actual posts. This patch ensures that no drafts are included in what's sent to algolia 😁 