### PR TITLE
Lots of updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,6 @@ Sync multiple content types from Contentful to Algolia
       [Function <manipulateSingle>]
     );
 
-## Note
-
-Algolia indexes need to have the following attributes searchable:
-
-* `id`
-* `locale`
-
 ## Example config
 
 You can find a sample configuration in [config.sample.js](./config.sample.js).

--- a/lib/Algolia.js
+++ b/lib/Algolia.js
@@ -2,6 +2,8 @@
  * Configuration and indexing functions of Algolia API
  */
 const algoliasearch = require('algoliasearch');
+const crypto = require('crypto');
+const _ = require('lodash');
 
 /**
  * Algolia Class
@@ -19,6 +21,7 @@ class Algolia {
 
     this.client = algoliasearch(config.applicationId, config.apiKey);
     this.index = this.client.initIndex(indexName);
+    this.cachedResults = null;
     this.indexName = indexName;
   }
 
@@ -27,27 +30,12 @@ class Algolia {
    * @param  {Object}  data All elements that should be indexed
    * @return {Promise}
    */
-  indexData (data) {
-    return new Promise((resolve, reject) => {
-      let newObjects = [];
-      let existingObjects = [];
-
-      Promise.resolve(
-        this.getElementsPromise(data)
-      ).then((results) => {
-        results.forEach((result) => {
-          if (result.exists) {
-            existingObjects.push(result.entry);
-          } else {
-            newObjects.push(result.entry);
-          }
-        });
-      })
-      .then(() => {
-        this.indexObjects(newObjects, existingObjects, resolve, reject);
+  indexData (data, contentType) {
+    return this.getElementsPromise(data, contentType)
+      .then((entries) => {
+        return this.indexObjects(entries.created, entries.updated, entries.deleted);
       })
       .catch(console.error);
-    });
   }
 
   /**
@@ -56,33 +44,60 @@ class Algolia {
    * @return {Promise}         Resolver holds the data of element and if it exists
    *                           or not
    */
-  getElementsPromise (data) {
-    let queries = data.map((element) => {
-      return `${element.id} ${element.locale}`;
-    });
-
-    return new Promise((resolve, reject) => {
-      this.getObjects(queries)
-        .then(results => {
-          results = results.results.map((result, index) => {
-            let entry = data[index];
-
-            if (result.hits && result.hits[0] && result.hits[0].objectID) {
-              entry.objectID = result.hits[0].objectID;
-            }
-
-            return {
-              exists: result.nbHits > 0,
-              entry
-            };
-          });
-
-          return resolve(results);
-        })
-        .catch((error) =>{
-          reject(error);
-          console.error(error);
+  getElementsPromise (data, contentType) {
+    // new method, match client side
+    let getEntryKey = (entry) => {
+      let hash = crypto.createHash('sha256');
+      hash.update(entry.id);
+      hash.update(entry.locale);
+      return hash.digest('hex');
+    };
+    let entriesIndex = _.keyBy(data, getEntryKey);
+    if (!this.cachedResults) {
+      let promise = new Promise((resolve, reject) => {
+        let browser = this.index.browseAll();
+        let results = [];
+        browser.on('result', function onResult(content) {
+          results = _.concat(results, content.hits);
         });
+
+        browser.on('end', function onEnd() {
+          resolve(results);
+        });
+
+        browser.on('error', function onError(err) {
+          reject(err);
+        });
+      });
+      this.cachedResults = promise;
+    }
+
+    return this.cachedResults.then(function (hits) {
+      if (contentType) {
+        hits = _.filter(hits, {contentType: contentType});
+      }
+
+      var results = {
+        created: [],
+        updated: [],
+        deleted: []
+      };
+      _.each(hits, (hit) => {
+        var key = getEntryKey(hit);
+        if (entriesIndex[key]) {
+          entriesIndex[key].objectID = hit.objectID;
+          var compactEntry = _.omitBy(entriesIndex[key], (prop) => { return _.isUndefined(prop); });
+          if (!_.isEqual(compactEntry, hit)) {
+            results.updated.push(entriesIndex[key]);
+          }
+        } else if (contentType) { // just in case
+          results.deleted.push(hit.objectID);
+        }
+      });
+
+      results.created = _.filter(data, (entry) => { return !entry.objectID; } );
+
+      return results;
     });
   }
 
@@ -94,16 +109,14 @@ class Algolia {
    * @param  {Function} reject          Reject
    * @return {Promise}
    */
-  indexObjects (newObjects, existingObjects, resolve, reject) {
+  indexObjects (newObjects, existingObjects, deletedObjects) {
     return Promise.all([
       this.addObjects(newObjects),
-      this.updateObjects(existingObjects)
+      this.updateObjects(existingObjects),
+      this.deleteObjects(deletedObjects)
     ]).then((data) => {
-      let objects = this.getMergedObjects(data);
-
-      resolve(objects);
-    })
-    .catch(reject);
+      return this.getMergedObjects(data);
+    });
   }
 
   /**
@@ -126,12 +139,16 @@ class Algolia {
    * @return {Promise} Resolves with the found elements
    */
   getIndex () {
+    let query = {
+      indexName: this.indexName,
+      params: {
+        restrictSearchableAttributes: ['id', 'locale']
+      }
+    };
+
     return new Promise((resolve, reject) => {
-      this.index.search({
-        query: '',
-        hitsPerPage: 100
-      }, (error, results) => {
-        if (error || (results && results.hits.length === 0)) {
+      this.client.browse(query, (error, results) => {
+        if (error) {
           return reject(error);
         }
 
@@ -139,6 +156,7 @@ class Algolia {
       });
     });
   }
+
 
   /**
    * Get an object from the index by its id attribute
@@ -225,6 +243,29 @@ class Algolia {
 
     return new Promise((resolve, reject) => {
       this.index.saveObjects(objects, (error, content) => {
+        if (error) {
+          return reject(error);
+        }
+
+        return resolve(content);
+      });
+    });
+  }
+
+  /**
+   * Delete existing objects from the index
+   * @param  {Array}   objects Objects to update
+   * @return {Promise}         Resolves with indexed objects
+   */
+  deleteObjects (objects) {
+    if (objects.length === 0) {
+      return {
+        objectIDs: []
+      };
+    }
+
+    return new Promise((resolve, reject) => {
+      this.index.deleteObjects(objects, (error, content) => {
         if (error) {
           return reject(error);
         }

--- a/lib/Contentful.js
+++ b/lib/Contentful.js
@@ -2,7 +2,8 @@
  * Contentful configuration and library
  */
 const contentful = require('contentful');
-const merge = require('lodash').merge;
+const _ = require('lodash');
+const merge = _.merge;
 
 const flatten = (array) => {
   return array.reduce((a, b) => {
@@ -112,10 +113,17 @@ class Contentful {
    * Clean entries a bit more (to reduce file size)
    * @param  {Object} entry  Entry to clean
    * @param  {Array}  locale Locales
+   * @param  {Array}  cleanStack Stack of entries already processed, for cycle detection
    * @return {Object}        Cleaned entry
    */
-  _cleanMore (entry, locale) {
+  _cleanMore (entry, locale, cleanStack) {
     let newEntry = {};
+
+    cleanStack = cleanStack || [];
+    if (_.indexOf(cleanStack, entry)) {
+      // circular reference detected, do not re-process this entry
+      return entry;
+    }
 
     for (let key in entry) {
       if (typeof entry[key] === 'object') {
@@ -134,7 +142,9 @@ class Contentful {
 
           newEntry[key] = merge(entry[key], newEntry[key]);
         } else {
-          newEntry[key] = this._cleanMore(entry[key], locale);
+          cleanStack.push(entry);
+          newEntry[key] = this._cleanMore(entry[key], locale, cleanStack);
+          cleanStack.pop();
         }
       }
     }

--- a/lib/Contentful.js
+++ b/lib/Contentful.js
@@ -2,7 +2,7 @@
  * Contentful configuration and library
  */
 const contentful = require('contentful');
-const merge = require('deepmerge');
+const merge = require('lodash').merge;
 
 const flatten = (array) => {
   return array.reduce((a, b) => {

--- a/lib/Contentful.js
+++ b/lib/Contentful.js
@@ -4,6 +4,7 @@
 const contentful = require('contentful');
 const _ = require('lodash');
 const merge = _.merge;
+const MAX_CONTENTFUL_RESULTS = 1000;
 
 const flatten = (array) => {
   return array.reduce((a, b) => {
@@ -38,6 +39,27 @@ class Contentful {
     this.locales = locales;
   }
 
+  getEntriesPaged(query, skip, previous) {
+    skip = skip || 0;
+    previous = previous || [];
+    query = _.extend({}, query, {
+      skip: skip,
+      limit: MAX_CONTENTFUL_RESULTS
+    });
+
+    return this.client
+      .getEntries(query)
+      .then((result) => {
+        var entries = _.concat(previous, result.items);
+        if (result.skip + MAX_CONTENTFUL_RESULTS < result.total) {
+          return this.getEntriesPaged(query, skip+MAX_CONTENTFUL_RESULTS, entries);
+        }
+        else {
+          return entries;
+        }
+      });
+  }
+
   /**
    * Get all entries of a specific type
    * @param  {String}   categoryId       Content type id
@@ -57,10 +79,9 @@ class Contentful {
         query['sys.id'] = entryId;
       }
 
-      this.client
-        .getEntries(query)
+      this.getEntriesPaged(query)
         .then((entries) => {
-          let data = entries.items.map((entry) => {
+          let data = entries.map((entry) => {
             const localizedEntries = this._getLocalizedEntries(entry);
             let localizedManipulatedEntries = localizedEntries;
 

--- a/lib/Sync.js
+++ b/lib/Sync.js
@@ -14,6 +14,7 @@ class Sync {
    */
   constructor (config) {
     this.config = config;
+    this.contentful = new Contentful(this.config.contentful, this.config.locales);
   }
 
   /**
@@ -21,11 +22,10 @@ class Sync {
    * @param  {String} type Name of index
    * @return {void}
    */
-  syncSingle (type) {
-    new Contentful(this.config.contentful, this.config.locales)
-      .getEntries(type, this.entryId, this.manipulateSingle)
+  syncSingle (type, algoliaInstance) {
+    return this.contentful.getEntries(type, this.entryId, this.manipulateSingle)
       .then((content) => {
-        this.singleCallback(type, content);
+        return this.singleCallback(type, content, algoliaInstance);
       })
       .catch(console.error);
   }
@@ -36,7 +36,7 @@ class Sync {
    * @param  {Object} content Content object that should be synced
    * @return {void}
    */
-  singleCallback (type, content) {
+  singleCallback (type, content, algoliaInstance) {
     // Convert to array
     if (content.constructor !== Array) {
       content = [content];
@@ -44,8 +44,7 @@ class Sync {
 
     this.callback && this.callback(content);
 
-    new Algolia(this.config.algolia, this.indexName)
-      .indexData(content)
+    return algoliaInstance.indexData(content, type)
       .then(() => {
         console.log(`Indexed type: ${type}`);
       })
@@ -73,10 +72,13 @@ class Sync {
     this.callback = callback;
     this.entryId = entryId;
     this.manipulateSingle = manipulateSingle;
+    let algoliaInstance = new Algolia(this.config.algolia, this.indexName);
+    let promises = [];
 
     contentTypes.forEach((type) => {
-      this.syncSingle(type);
+      promises.push(this.syncSingle(type, algoliaInstance));
     });
+    return Promise.all(promises);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "algoliasearch": "^3.20.3",
-    "contentful": "^3.8.0",
+    "contentful": "^4.6.0",
     "deepmerge": "^1.3.1",
     "eslint": "^3.13.1"
   },

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "dependencies": {
     "algoliasearch": "^3.20.3",
     "contentful": "^4.6.0",
-    "deepmerge": "^1.3.1",
-    "eslint": "^3.13.1"
+    "eslint": "^3.13.1",
+    "lodash": "^4.17.4"
   },
   "cacheDirectories": [
     "node_modules"

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,6 +65,17 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
+aproba@^1.0.3:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.1.2.tgz#45c6629094de4e96f693ef7eab74ae079c240fc1"
+
+are-we-there-yet@~1.1.2:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz#bb5dca382bb94f05e15194373d16fd3ba1ca110d"
+  dependencies:
+    delegates "^1.0.0"
+    readable-stream "^2.0.6"
+
 argparse@^1.0.7:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.9.tgz#73d83bc263f86e97f8cc4f6bae1b0e90a7d22c86"
@@ -85,6 +96,12 @@ arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
+axios@~0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.15.3.tgz#2c9d638b2e191a08ea1d6cc988eadd6ba5bdc053"
+  dependencies:
+    follow-redirects "1.0.0"
+
 babel-code-frame@^6.16.0:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.20.0.tgz#b968f839090f9a8bc6d41938fb96cb84f7387b26"
@@ -92,12 +109,6 @@ babel-code-frame@^6.16.0:
     chalk "^1.1.0"
     esutils "^2.0.2"
     js-tokens "^2.0.0"
-
-babel-runtime@^6.3.19, babel-runtime@~6.3.19:
-  version "6.3.19"
-  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.3.19.tgz#f2db696c3c8c379881e2a53665e02187074dc681"
-  dependencies:
-    core-js "^1.2.0"
 
 balanced-match@^0.4.1:
   version "0.4.2"
@@ -168,27 +179,28 @@ concat-stream@^1.4.6:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
-contentful-sdk-core@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/contentful-sdk-core/-/contentful-sdk-core-2.5.0.tgz#e1cad6b7660654bb1095b385fd5abc225199273f"
+console-control-strings@^1.0.0, console-control-strings@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
+
+contentful-sdk-core@^3.14.1:
+  version "3.14.3"
+  resolved "https://registry.yarnpkg.com/contentful-sdk-core/-/contentful-sdk-core-3.14.3.tgz#083b482f78512d2799204f8059dd0fdfad1af301"
   dependencies:
-    babel-runtime "^6.3.19"
-    follow-redirects "0.0.7"
-    lodash "^4.2.0"
+    es6-promise "^4.0.5"
+    lodash "^4.17.4"
+    npmlog "^4.0.2"
     qs "^6.1.0"
 
-contentful@^3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/contentful/-/contentful-3.8.0.tgz#3ad3acf59c17b3ed7874f23286cc4f0cc00dd0e9"
+contentful@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/contentful/-/contentful-4.6.0.tgz#43937dcf3b973d2e9674227f7e5483e703cfc7b6"
   dependencies:
-    babel-runtime "~6.3.19"
-    contentful-sdk-core "~2.5.0"
-    json-stringify-safe "~5.0.1"
-    lodash "~4.2.0"
-
-core-js@^1.2.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
+    axios "~0.15.3"
+    contentful-sdk-core "^3.14.1"
+    es6-promise "^4.0.5"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.4"
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -210,10 +222,6 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
-deepmerge@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-1.3.1.tgz#682ba92402574115b865edce525665814296a39b"
-
 del@^2.0.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/del/-/del-2.2.2.tgz#c12c981d067846c84bcaf862cff930d907ffd1a8"
@@ -225,6 +233,10 @@ del@^2.0.2:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
     rimraf "^2.2.8"
+
+delegates@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
 doctrine@^1.2.2:
   version "1.5.0"
@@ -428,12 +440,11 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-follow-redirects@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-0.0.7.tgz#34b90bab2a911aa347571da90f22bd36ecd8a919"
+follow-redirects@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.0.0.tgz#8e34298cbd2e176f254effec75a1c78cc849fd37"
   dependencies:
     debug "^2.2.0"
-    stream-consume "^0.1.0"
 
 foreach@^2.0.5:
   version "2.0.5"
@@ -442,6 +453,19 @@ foreach@^2.0.5:
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+gauge@~2.7.3:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
+  dependencies:
+    aproba "^1.0.3"
+    console-control-strings "^1.0.0"
+    has-unicode "^2.0.0"
+    object-assign "^4.1.0"
+    signal-exit "^3.0.0"
+    string-width "^1.0.1"
+    strip-ansi "^3.0.1"
+    wide-align "^1.1.0"
 
 generate-function@^2.0.0:
   version "2.0.0"
@@ -495,6 +519,10 @@ has-ansi@^2.0.0:
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
   dependencies:
     ansi-regex "^2.0.0"
+
+has-unicode@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
 
 ignore@^3.2.0:
   version "3.2.0"
@@ -611,7 +639,7 @@ json-stable-stringify@^1.0.0, json-stable-stringify@^1.0.1:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
 
@@ -634,11 +662,11 @@ load-script@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/load-script/-/load-script-1.0.0.tgz#0491939e0bee5643ee494a7e3da3d2bac70c6ca4"
 
-lodash@^4.0.0, lodash@^4.2.0, lodash@~4.2.0:
+lodash@^4.0.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.2.1.tgz#171fdcfbbc30d689c544cd18c0529f56de6c1aa9"
 
-lodash@^4.3.0:
+lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -675,6 +703,15 @@ mute-stream@0.0.5:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+npmlog@^4.0.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
+  dependencies:
+    are-we-there-yet "~1.1.2"
+    console-control-strings "~1.1.0"
+    gauge "~2.7.3"
+    set-blocking "~2.0.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -767,7 +804,7 @@ re-emitter@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/re-emitter/-/re-emitter-1.1.3.tgz#fa9e319ffdeeeb35b27296ef0f3d374dac2f52a7"
 
-readable-stream@^2.0.0, readable-stream@^2.1.5, readable-stream@^2.2.2:
+readable-stream@^2.0.0, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.2.tgz#a9e6fec3c7dda85f8bb1b3ba7028604556fc825e"
   dependencies:
@@ -850,6 +887,10 @@ semver@^5.1.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
+set-blocking@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+
 shelljs@^0.7.5:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.7.6.tgz#379cccfb56b91c8601e4793356eb5382924de9ad"
@@ -857,6 +898,10 @@ shelljs@^0.7.5:
     glob "^7.0.0"
     interpret "^1.0.0"
     rechoir "^0.6.2"
+
+signal-exit@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
 slice-ansi@0.0.4:
   version "0.0.4"
@@ -872,11 +917,7 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-stream-consume@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/stream-consume/-/stream-consume-0.1.0.tgz#a41ead1a6d6081ceb79f65b061901b6d8f3d1d0f"
-
-string-width@^1.0.1:
+string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
   dependencies:
@@ -895,7 +936,7 @@ string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
-strip-ansi@^3.0.0:
+strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
@@ -1000,6 +1041,12 @@ user-home@^2.0.0:
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+wide-align@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
+  dependencies:
+    string-width "^1.0.2"
 
 wordwrap@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Sorry for the monolithic pull request, but there were some interdependencies and I was on a tight timeline.

Basically, here are the changes included:
* Update Contentful client version
* Make `Sync.sync` return a promise that doesn't resolve until the indexes have been updated.
* Fix a stack overflow error in `_cleanMore` when the Contentful has a cyclical reference (in my case, 2 blog posts with "relatedPost" fields that linked to each other). You'll still get an error when it tries to save to Algolia (because you can't serialize a circular structure like that to JSON), but you can work around that easily enough by using `manipulateSingle` to remove those references in a way that makes sense for your data set.
* Fetch more than 100 records per content type from Contentful if they're available. This has 2 parts: supporting multiple pages of results, and increasing the page size to 1000 (to reduce the number of requests required).
* Delete records from the Algolia index that are no longer in Contentful. This works by pulling down all the records in the Algolia index and comparing the contentType, locale, and id locally. This has the advantage of not requiring id/locale to be searchable in algolia, but is a bit more chatty. I couldn't think of a better way of doing this without causing excessive index updates. I also wasn't sure if the batch update option you were using would continue to scale for very large batch sizes. On the bright side this enables:
* Don't update the Algolia index for Contentful entries that are the same as what's already there. Since Algolia charges you for indexing operations this is nice to have.


I did explore using the Contentful synchronization API instead of the current option, but it doesn't appear to support includes/filtering by content type very well. I tried a couple of different paths but in the end I decided I couldn't reliably detect changes to the content of includes and so I decided to just go down this route...