### PR TITLE
Added support for Contentful environnements

### DIFF
--- a/config.sample.js
+++ b/config.sample.js
@@ -13,7 +13,8 @@ module.exports = {
   contentful: {
     accessToken: process.env.CONTENTFUL_ACCESSTOKEN,
     space: process.env.CONTENTFUL_SPACE,
-    host: 'preview.contentful.com' // for Drafts
+    host: 'preview.contentful.com', // for Drafts
+    environment: 'master' // the default env on Contentful
   },
 
   locales: [

--- a/lib/Contentful.js
+++ b/lib/Contentful.js
@@ -24,7 +24,8 @@ class Contentful {
     const clientConfig = {
       space: config.space,
       accessToken: config.accessToken,
-      host: config.host
+      host: config.host,
+      environment: config.environment,
     };
 
     /**

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "algoliasearch": "^3.24.11",
-    "contentful": "^5.1.1",
+    "contentful": "^6.1.0",
     "eslint": "^3.13.1",
     "lodash": "^4.17.4"
   },


### PR DESCRIPTION
Hi,

Contentful now offers _environments_, added the config parameter to the client connection. Contentful version package.json was too old to support this, add to bump it to a newer version.

Can you merge and bump your master ? 

Thanks, best regards.